### PR TITLE
Remove global pull request template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,0 @@
-## Summary of the changes / Why this is an improvement
-
-
-## Checklist
-
- - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed


### PR DESCRIPTION
The file PULL_REQUEST_TEMPLATE.md is applied on all repositories, not
only public ones.
Although, having a minimalistic PR template for our public repositories
seems to be a nice thing, the much greater downside is that it is also
used for all internal, private repos, which are of much greater number
than our public ones.

I propose to remove the global PR template in favour of adding PR
templates explicitly to relevant public repositories. Repositories, such
as `crate/crate` already have one which is also more tied to the
specifics of the repo.