### PR TITLE
Bmunkholm/workflow

### DIFF
--- a/.github/workflows/cla-check-workflow.yml
+++ b/.github/workflows/cla-check-workflow.yml
@@ -1,0 +1,70 @@
+name: Check PR Author has signed CLA
+
+# Checks that the author of a PR has signed the CLA.
+# If they have, a CLA_SIGNED label is added.
+# If they haven't a NEEDS_CLA label is added and a comment to sign the CLA is made.
+# A re-check is done if a new commit is made or a label is removed (e.g. the NEEDS_CLA label).
+# The comment will only be made if the NEEDS_CLA label isn't there.
+# Labels are automatically created, if they don't exist already.
+
+on:
+  workflow_call:              # Call from another workflow
+    inputs:
+      CLA_SIGNED:             # Label to add when user has signed CLA
+        default: 'cla-signed'
+        type: string
+      NEEDS_CLA:              # Label to add when user has not signed CLA
+        default: 'needs CLA'
+        type: string
+  
+jobs:
+  check-author-signed-cla:
+    runs-on: ubuntu-22.04
+    env:
+      CLA_SIGNED: ${{ inputs.CLA_SIGNED }}
+      NEEDS_CLA: ${{ inputs.NEEDS_CLA }}
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+    steps:
+      - name: Verify PR Author
+        id: check_author
+        run: |
+          # Contributer names that signed CLA are in the first field in the csv file 
+          gh api repos/crate/clabot-config/contents/contributors.csv \
+            -H "Accept: application/vnd.github.v3.raw" \
+            | cut -d',' -f1 > authorized_users.txt
+
+          if grep -Fxq "${{ github.event.pull_request.user.login }}" authorized_users.txt; then
+            echo "authorized=true" >> $GITHUB_OUTPUT
+          else
+            echo "authorized=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          # accessing another repo requires a PAT (https://github.com/orgs/community/discussions/46566)
+          GH_TOKEN: ${{ secrets.REPO_CLABOT_READ_CONTENT_ACCESS }}
+
+      - name: Ensure labels exist
+        run: |
+          # Adding labels won't overwrite existing description or color if they already exist
+          gh label create "$NEEDS_CLA" --description "Contributor has not signed the CLA yet." --color FBCA04 --repo ${{ github.repository }} || true
+          gh label create "$CLA_SIGNED" --color ededed --repo ${{ github.repository }} || true
+      
+      - name: Add CLA_SIGNED label if author is authorized
+        if: ${{ steps.check_author.outputs.authorized == 'true' }}
+        run: |
+          gh issue edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label "$CLA_SIGNED"
+          gh issue edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --remove-label "$NEEDS_CLA"
+      
+      - name: Add NEEDS_CLA label and comment if the author is not authorized
+        if: ${{ steps.check_author.outputs.authorized == 'false' }}
+        run: |
+          # We don't want to be noisy, so if the NEEDS_CLA label is already there, then don't comment again
+          if ! gh issue view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json labels -q '.labels[].name' | grep -qx "$NEEDS_CLA"; then
+            gh issue edit ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --add-label "$NEEDS_CLA"
+            gh pr comment ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --body "Hello, @${{ github.event.pull_request.user.login }}.
+            Thank you for your contribution! We require all our contributors to sign our [Contributor License Agreement](https://cratedb.com/developers/community/contribute) before we can merge any code. Once done, we will be able to accept your contribution assuming a positive review.
+            To rerun the CLA check, remove the '$NEEDS_CLA' label."
+          fi
+          echo "User ${{ github.event.pull_request.user.login }} has NOT signed the CLA yet"
+          exit 2
+          

--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -1,0 +1,8 @@
+name: Check PR Author has signed CLA
+on:
+  pull_request:
+    types: [opened, synchronize, unlabeled]
+jobs:
+  check-author-signed-cla:
+    uses: crate/.github/.github/workflows/cla-check-workflow.yml@main
+    secrets: inherit


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Add a reusable workflow to check CLA is signed for PR contributors.
The "cla-check.yml" can be added to all repos that wants to check CLA signatures.
